### PR TITLE
NGC-1879: Return CONFLICT, rather than SERVICE_UNAVAILABLE

### DIFF
--- a/app/uk/gov/hmrc/pushnotification/controllers/CallbackController.scala
+++ b/app/uk/gov/hmrc/pushnotification/controllers/CallbackController.scala
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait CallbackControllerApi extends BaseController with ErrorHandling {
   val NoCallbacks: JsValue = Json.parse("""{"code":"NOT_FOUND","message":"No callbacks found"}""")
 
-  val LockFailed: JsValue = Json.parse("""{"code":"SERVICE_UNAVAILABLE","message":"Failed to obtain lock"}""")
+  val LockFailed: JsValue = Json.parse("""{"code":"CONFLICT","message":"Failed to obtain lock"}""")
 
   def getUndeliveredCallbacks: Action[AnyContent]
 
@@ -56,7 +56,7 @@ class CallbackController @Inject()(service: CallbackServiceApi) extends Callback
           else {
             Ok(Json.toJson(callbacks))
           }
-        }.getOrElse(ServiceUnavailable(LockFailed))
+        }.getOrElse(Conflict(LockFailed))
       }
       )
   }

--- a/app/uk/gov/hmrc/pushnotification/controllers/NotificationsController.scala
+++ b/app/uk/gov/hmrc/pushnotification/controllers/NotificationsController.scala
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait NotificationsControllerApi extends BaseController with ErrorHandling {
   val NoNotifications: JsValue = Json.parse("""{"code":"NOT_FOUND","message":"No notifications found"}""")
 
-  val LockFailed: JsValue = Json.parse("""{"code":"SERVICE_UNAVAILABLE","message":"Failed to obtain lock"}""")
+  val LockFailed: JsValue = Json.parse("""{"code":"CONFLICT","message":"Failed to obtain lock"}""")
 
   def getQueuedNotifications: Action[AnyContent]
 
@@ -83,7 +83,7 @@ class NotificationsController @Inject()(service: NotificationsServiceApi) extend
           else {
             Ok(Json.toJson(notifications))
           }
-        }.getOrElse(ServiceUnavailable(LockFailed))
+        }.getOrElse(Conflict(LockFailed))
       }
       )
   }

--- a/test/uk/gov/hmrc/pushnotification/controllers/CallbackControllerSpec.scala
+++ b/test/uk/gov/hmrc/pushnotification/controllers/CallbackControllerSpec.scala
@@ -126,11 +126,11 @@ class CallbackControllerSpec  extends UnitSpec with WithFakeApplication with Sca
       jsonBodyOf(result) shouldBe Json.parse("""{"code":"NOT_FOUND","message":"No callbacks found"}""")
     }
 
-    "return Service Unavailable (503) when it is not possible to obtain the mongo lock" in new LockFailed {
+    "return CONFLICT (409) when it is not possible to obtain the mongo lock" in new LockFailed {
       val result: Result = await(controller.getUndeliveredCallbacks()(emptyRequest))
 
-      status(result) shouldBe 503
-      jsonBodyOf(result) shouldBe Json.parse("""{"code":"SERVICE_UNAVAILABLE","message":"Failed to obtain lock"}""")
+      status(result) shouldBe 409
+      jsonBodyOf(result) shouldBe Json.parse("""{"code":"CONFLICT","message":"Failed to obtain lock"}""")
 
     }
 

--- a/test/uk/gov/hmrc/pushnotification/controllers/NotificationsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pushnotification/controllers/NotificationsControllerSpec.scala
@@ -108,11 +108,11 @@ class NotificationsControllerSpec extends UnitSpec with WithFakeApplication with
       jsonBodyOf(result) shouldBe Json.parse("""{"code":"NOT_FOUND","message":"No notifications found"}""")
     }
 
-    "return Service Unavailable (503) when it is not possible to obtain the mongo lock" in new LockFailed {
+    "return Conflict (409) when it is not possible to obtain the mongo lock" in new LockFailed {
       val result: Result = await(controller.getQueuedNotifications()(emptyRequest))
 
-      status(result) shouldBe 503
-      jsonBodyOf(result) shouldBe Json.parse("""{"code":"SERVICE_UNAVAILABLE","message":"Failed to obtain lock"}""")
+      status(result) shouldBe 409
+      jsonBodyOf(result) shouldBe Json.parse("""{"code":"CONFLICT","message":"Failed to obtain lock"}""")
 
     }
 
@@ -144,11 +144,11 @@ class NotificationsControllerSpec extends UnitSpec with WithFakeApplication with
       jsonBodyOf(result) shouldBe Json.parse("""{"code":"NOT_FOUND","message":"No notifications found"}""")
     }
 
-    "return Service Unavailable (503) when it is not possible to obtain the mongo lock" in new LockFailed {
+    "return CONFLICT (409) when it is not possible to obtain the mongo lock" in new LockFailed {
       val result: Result = await(controller.getTimedOutNotifications()(emptyRequest))
 
-      status(result) shouldBe 503
-      jsonBodyOf(result) shouldBe Json.parse("""{"code":"SERVICE_UNAVAILABLE","message":"Failed to obtain lock"}""")
+      status(result) shouldBe 409
+      jsonBodyOf(result) shouldBe Json.parse("""{"code":"CONFLICT","message":"Failed to obtain lock"}""")
 
     }
 


### PR DESCRIPTION
Return CONFLICT, rather than SERVICE_UNAVAILABLE, when the mongo lock cannot be obtained