### PR TITLE
NGC-2402 Updated implementation of getMessageByMessageId.

### DIFF
--- a/app/uk/gov/hmrc/pushnotification/controllers/PushMessageController.scala
+++ b/app/uk/gov/hmrc/pushnotification/controllers/PushMessageController.scala
@@ -106,14 +106,9 @@ class PushMessageController @Inject()(service: PushMessageServiceApi, accessCont
   override def getMessageFromMessageId(messageId:String, journeyId: Option[String]): Action[AnyContent] =
     accessControl.validateAccept(acceptHeaderValidationRules).async {
       implicit request =>
-
         errorWrapper {
           def getAuthId = request.authority.fold(throw new Exception("no auth!")){auth => auth.authInternalId}
-          val maybeMessages: Future[Option[PushMessage]] = for (
-            message <- service.getMessageFromMessageId(messageId, getAuthId)
-          ) yield message
-
-          maybeMessages.map {
+          service.getMessageFromMessageId(messageId, getAuthId).map {
             _.fold(NotFound("Message Id unknown!")) { found => Ok(Json.toJson(found)) }
           }
         }

--- a/app/uk/gov/hmrc/pushnotification/controllers/PushMessageController.scala
+++ b/app/uk/gov/hmrc/pushnotification/controllers/PushMessageController.scala
@@ -40,7 +40,7 @@ trait PushMessageControllerApi extends BaseController with HeaderValidator with 
 
   def getCurrentMessages(journeyId: Option[String] = None): Action[AnyContent]
 
-  def getMessageFromMessageId(messageId:String, journeyId: Option[String]): Action[JsValue]
+  def getMessageFromMessageId(messageId:String, journeyId: Option[String]): Action[AnyContent]
 }
 
 @Singleton
@@ -103,13 +103,17 @@ class PushMessageController @Inject()(service: PushMessageServiceApi, accessCont
         }
     }
 
-  override def getMessageFromMessageId(messageId:String, journeyId: Option[String]): Action[JsValue] =
-    accessControl.validateAccept(acceptHeaderValidationRules).async(BodyParsers.parse.json) {
+  override def getMessageFromMessageId(messageId:String, journeyId: Option[String]): Action[AnyContent] =
+    accessControl.validateAccept(acceptHeaderValidationRules).async {
       implicit request =>
 
         errorWrapper {
           def getAuthId = request.authority.fold(throw new Exception("no auth!")){auth => auth.authInternalId}
-          service.getMessageFromMessageId(messageId, getAuthId).map {
+          val maybeMessages: Future[Option[PushMessage]] = for (
+            message <- service.getMessageFromMessageId(messageId, getAuthId)
+          ) yield message
+
+          maybeMessages.map {
             _.fold(NotFound("Message Id unknown!")) { found => Ok(Json.toJson(found)) }
           }
         }

--- a/app/uk/gov/hmrc/pushnotification/domain/PushMessage.scala
+++ b/app/uk/gov/hmrc/pushnotification/domain/PushMessage.scala
@@ -62,10 +62,10 @@ object PushMessageStatus {
   val reads: Reads[PushMessageStatus] = new Reads[PushMessageStatus] {
     override def reads(json: JsValue): JsResult[PushMessageStatus] =
       json match {
-        case JsString(value: String) if value == Acknowledge.toString => JsSuccess(Acknowledge)
-        case JsString(value: String) if value == Answer.toString => JsSuccess(Answer)
-        case JsString(value: String) if value == Timeout.toString => JsSuccess(Timeout)
-        case JsString(value: String) if value == PermanentlyFailed.toString => JsSuccess(PermanentlyFailed)
+        case JsString(value: String) if value == Acknowledge.toString ⇒ JsSuccess(Acknowledge)
+        case JsString(value: String) if value == Answer.toString ⇒ JsSuccess(Answer)
+        case JsString(value: String) if value == Timeout.toString ⇒ JsSuccess(Timeout)
+        case JsString(value: String) if value == PermanentlyFailed.toString ⇒ JsSuccess(PermanentlyFailed)
         case _ => JsError(s"Failed to resolve $json")
       }
   }

--- a/app/uk/gov/hmrc/pushnotification/services/PushMessageService.scala
+++ b/app/uk/gov/hmrc/pushnotification/services/PushMessageService.scala
@@ -66,10 +66,10 @@ class PushMessageService @Inject()(connector: PushRegistrationConnector, notific
 
     def findCallback(message:Option[PushMessage]): Future[Option[PushMessage]] = {
       val notFound:Option[PushMessage] = None
-      message.fold(Future.successful(notFound)) { found =>
+      message.fold(Future.successful(notFound)) { found ⇒
         callbackRepository.findLatest(List(messageId)).map {
-          case (callback :: _) if Seq(Acknowledge, Answer).contains(callback.status) => message
-          case _ => None
+          case (callback :: _) ⇒ None
+          case _ ⇒ message
         }
       }
     }

--- a/test/uk/gov/hmrc/pushnotification/controllers/PushMessageControllerSpec.scala
+++ b/test/uk/gov/hmrc/pushnotification/controllers/PushMessageControllerSpec.scala
@@ -304,7 +304,7 @@ class PushMessageControllerSpec extends UnitSpec with WithFakeApplication with S
     "return unanswered message for a given authId" in new Success {
       when(mockService.getMessageFromMessageId(any[String], any[String])).thenReturn(Future(Some(someMessage)))
 
-      val result: Result = await(controller.getMessageFromMessageId(someMessageId, None)(emptyJsonRequest))
+      val result: Result = await(controller.getMessageFromMessageId(someMessageId, None)(emptyGetRequest))
 
       status(result) shouldBe 200
       jsonBodyOf(result) shouldBe Json.parse(
@@ -322,7 +322,7 @@ class PushMessageControllerSpec extends UnitSpec with WithFakeApplication with S
     "return no message when no messages are associated with authId" in new Success {
       when(mockService.getMessageFromMessageId(any[String], any[String])).thenReturn(Future(None))
 
-      val result: Result = await(controller.getMessageFromMessageId(otherMessageId, None)(emptyJsonRequest))
+      val result: Result = await(controller.getMessageFromMessageId(otherMessageId, None)(emptyGetRequest))
 
       status(result) shouldBe 404
     }
@@ -330,14 +330,14 @@ class PushMessageControllerSpec extends UnitSpec with WithFakeApplication with S
     "return 500 result when bad service unavailable exception is thrown by service" in new DownstreamFailure {
       when(mockService.getMessageFromMessageId(any[String], any[String])).thenReturn(Future(throw new ServiceUnavailableException("service unavailable")))
 
-      val result: Result = await(controller.getMessageFromMessageId(otherMessageId, None)(emptyJsonRequest))
+      val result: Result = await(controller.getMessageFromMessageId(otherMessageId, None)(emptyGetRequest))
 
       status(result) shouldBe 500
       jsonBodyOf(result) shouldBe Json.parse("""{"code":"INTERNAL_SERVER_ERROR","message":"Internal server error"}""")
     }
 
     "return 401 result when authority record does not contain an internal-id" in new AuthFailure {
-      val result: Result = await(controller.getMessageFromMessageId(someMessageId, None)(emptyJsonRequest))
+      val result: Result = await(controller.getMessageFromMessageId(someMessageId, None)(emptyGetRequest))
 
       status(result) shouldBe 401
       jsonBodyOf(result) shouldBe Json.parse("""{"code":"UNAUTHORIZED","message":"Account id error"}""")


### PR DESCRIPTION
Removed body parsing of GET endpoint, no json payload to parse.
Updated findCallback service implementation to only return if no
callback has been made. Updated test cases.