### PR TITLE
Fix bug in multiple-message version of findLatest introduced in NGC-2095

### DIFF
--- a/app/uk/gov/hmrc/pushnotification/repository/CallbackMongoRepository.scala
+++ b/app/uk/gov/hmrc/pushnotification/repository/CallbackMongoRepository.scala
@@ -85,10 +85,21 @@ class CallbackMongoRepository @Inject()(mongo: DB, @Named("clientCallbackMaxRetr
         }
       }
 
-  override def findLatest(messageIds: List[String]): Future[List[PushMessageCallbackPersist]] =
+
+  override def findLatest(messageId: String): Future[Option[PushMessageCallbackPersist]] =
+    collection.
+      find(Json.obj("messageId" -> messageId)).
+      sort(Json.obj("status" -> -1)).
+      one[PushMessageCallbackPersist](ReadPreference.primaryPreferred)
+
+  override def findLatest(messageIds: Seq[String]): Future[Map[String, PushMessageCallbackPersist]] =
     collection.find(Json.obj("messageId" -> Json.obj("$in" -> messageIds)))
       .sort(Json.obj("status" -> -1))
-      .cursor[PushMessageCallbackPersist](ReadPreference.primaryPreferred).collect[List]()
+      .cursor[PushMessageCallbackPersist](ReadPreference.primaryPreferred).collect[List]().map(onlyFirstWithEachMessageId)
+
+  private def onlyFirstWithEachMessageId(messages: List[PushMessageCallbackPersist]): Map[String, PushMessageCallbackPersist] =
+    messages.groupBy(_.messageId).map(entry => (entry._1, entry._2.head))
+
 
   override def findByStatus(messageId: String, status: PushMessageStatus): Future[Option[PushMessageCallbackPersist]] =
     collection.
@@ -206,7 +217,9 @@ trait CallbackRepositoryApi {
 
   def update(result: CallbackResult): Future[Either[String, PushMessageCallbackPersist]]
 
-  def findLatest(messageIds: List[String]): Future[List[PushMessageCallbackPersist]]
+  def findLatest(messageIds: String): Future[Option[PushMessageCallbackPersist]]
+
+  def findLatest(messageIds: Seq[String]): Future[Map[String, PushMessageCallbackPersist]]
 
   def findByStatus(messageId: String, status: PushMessageStatus): Future[Option[PushMessageCallbackPersist]]
 


### PR DESCRIPTION
It used to return all callbacks for all of the messages, but it should return only the latest callback for each message.

Also:

- Fix bug in PushMessageService.getMessagesByAuthority where it would match callbacks to the wrong messages if there was a message without a callback and one or more messages after that one.
- Reintroduce single-message version of findLatest for convenience when only 1 message is needed.