### PR TITLE
Use when instead of doReturn / doAnswer for stubbing

### DIFF
--- a/test/uk/gov/hmrc/pushnotification/connector/AuthConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pushnotification/connector/AuthConnectorSpec.scala
@@ -17,14 +17,14 @@
 package uk.gov.hmrc.pushnotification.connector
 
 import org.mockito.ArgumentMatchers.{any, contains, endsWith}
-import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.domain.{Nino, SaUtr}
 import uk.gov.hmrc.play.auth.microservice.connectors.ConfidenceLevel
-import uk.gov.hmrc.play.http.ws.WSHttp
 import uk.gov.hmrc.play.http._
+import uk.gov.hmrc.play.http.ws.WSHttp
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext
@@ -54,8 +54,8 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       val authResponse = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, saUtr, nino, oid)))
       val oidResponse = HttpResponse(200, Some(idsJson(internalId, externalId)))
 
-      doReturn(successful(authResponse), Nil: _*).when(mockHttp).GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
-      doReturn(successful(oidResponse), Nil: _*).when(mockHttp).GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
+      when(mockHttp.GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(authResponse))
+      when(mockHttp.GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(oidResponse))
 
       val authority: Authority = await(new AuthConnector(serviceUrl, serviceConfidenceLevel, mockHttp).grantAccess())
 
@@ -75,8 +75,8 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       val authResponse = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, saUtr, nino, oid)))
       val oidResponse = HttpResponse(200, Some(Json.parse("""{ "foo": "bar" }""")))
 
-      doReturn(successful(authResponse), Nil: _*).when(mockHttp).GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
-      doReturn(successful(oidResponse), Nil: _*).when(mockHttp).GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
+      when(mockHttp.GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(authResponse))
+      when(mockHttp.GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(oidResponse))
 
       try {
         await(new AuthConnector(serviceUrl, serviceConfidenceLevel, mockHttp).grantAccess())
@@ -98,8 +98,8 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, saUtr, nino, "ab12cd34")))
       val oidResponse = HttpResponse(200, Some(idsJson("foo", "bar")))
 
-      doReturn(successful(response), Nil: _*).when(mockHttp).GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
-      doReturn(successful(oidResponse), Nil: _*).when(mockHttp).GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
+      when(mockHttp.GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(response))
+      when(mockHttp.GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(oidResponse))
 
       try {
         await(new AuthConnector(serviceUrl, serviceConfidenceLevel, mockHttp).grantAccess())
@@ -122,8 +122,8 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, saUtr, nino, "ab12cd34")))
       val oidResponse = HttpResponse(200, Some(idsJson("foo", "bar")))
 
-      doReturn(successful(response), Nil: _*).when(mockHttp).GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
-      doReturn(successful(oidResponse), Nil: _*).when(mockHttp).GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
+      when(mockHttp.GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(response))
+      when(mockHttp.GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(oidResponse))
 
       await(new AuthConnector(serviceUrl, serviceConfidenceLevel, mockHttp).grantAccess())
     }
@@ -138,8 +138,8 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, saUtr, nino, "ab12cd34")))
       val oidResponse = HttpResponse(200, Some(idsJson("foo", "bar")))
 
-      doReturn(successful(response), Nil: _*).when(mockHttp).GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
-      doReturn(successful(oidResponse), Nil: _*).when(mockHttp).GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
+      when(mockHttp.GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(response))
+      when(mockHttp.GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(oidResponse))
 
       await(new AuthConnector(serviceUrl, serviceConfidenceLevel, mockHttp).grantAccess())
 
@@ -154,8 +154,8 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, saUtr, nino, "ab12cd34")))
       val oidResponse = HttpResponse(200, Some(idsJson("foo", "bar")))
 
-      doReturn(successful(response), Nil: _*).when(mockHttp).GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
-      doReturn(successful(oidResponse), Nil: _*).when(mockHttp).GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
+      when(mockHttp.GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(response))
+      when(mockHttp.GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(oidResponse))
 
       try {
         await(new AuthConnector(serviceUrl, serviceConfidenceLevel, mockHttp).grantAccess())
@@ -183,8 +183,8 @@ class AuthConnectorSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, saUtr, nino, "ab12cd34")))
       val oidResponse = HttpResponse(200, Some(idsJson("foo", "bar")))
 
-      doReturn(successful(response), Nil: _*).when(mockHttp).GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
-      doReturn(successful(oidResponse), Nil: _*).when(mockHttp).GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())
+      when(mockHttp.GET[HttpResponse](endsWith("/authority"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(response))
+      when(mockHttp.GET[HttpResponse](contains("/oid"))(any[HttpReads[HttpResponse]](), any[HeaderCarrier]())).thenReturn(successful(oidResponse))
 
       try {
         new AuthConnector(serviceUrl, serviceConfidenceLevel, mockHttp).grantAccess()

--- a/test/uk/gov/hmrc/pushnotification/connector/PushRegistrationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pushnotification/connector/PushRegistrationConnectorSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.pushnotification.connector
 
 import org.mockito.ArgumentMatchers.{any, matches}
-import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import uk.gov.hmrc.play.http._
@@ -41,11 +41,11 @@ class PushRegistrationConnectorSpec extends UnitSpec with ScalaFutures {
     val someId = "int-some-id"
     val otherId = "int-other-id"
     val brokenId = "int-broken-id"
-    val endpoints = Map("end:point:a" -> "windows", "end:point:b" -> "android")
+    val endpoints = Map[String, String]("end:point:a" -> "windows", "end:point:b" -> "android")
 
-    doReturn(successful(endpoints), Nil: _*).when(mockHttp).GET[Seq[String]](matches(s"${connector.serviceUrl}/push/endpoint/$someId"))(any[HttpReads[Seq[String]]](), any[HeaderCarrier]())
-    doReturn(failed(new NotFoundException("nothing for you here")), Nil: _*).when(mockHttp).GET[Seq[String]](matches(s"${connector.serviceUrl}/push/endpoint/$otherId"))(any[HttpReads[Seq[String]]](), any[HeaderCarrier]())
-    doReturn(failed(Upstream5xxResponse("BOOOOM!", 500, 500)), Nil: _*).when(mockHttp).GET[Seq[String]](matches(s"${connector.serviceUrl}/push/endpoint/$brokenId"))(any[HttpReads[Seq[String]]](), any[HeaderCarrier]())
+    when(mockHttp.GET[Map[String, String]](matches(s"${connector.serviceUrl}/push/endpoint/$someId"))(any[HttpReads[Map[String, String]]](), any[HeaderCarrier]())).thenReturn(successful(endpoints))
+    when(mockHttp.GET[Map[String, String]](matches(s"${connector.serviceUrl}/push/endpoint/$otherId"))(any[HttpReads[Map[String, String]]](), any[HeaderCarrier]())).thenReturn(failed(new NotFoundException("nothing for you here")))
+    when(mockHttp.GET[Map[String, String]](matches(s"${connector.serviceUrl}/push/endpoint/$brokenId"))(any[HttpReads[Map[String, String]]](), any[HeaderCarrier]())).thenReturn(failed(Upstream5xxResponse("BOOOOM!", 500, 500)))
   }
 
   "PushRegistrationConnector endpointsForAuthId" should {

--- a/test/uk/gov/hmrc/pushnotification/services/CallbackServiceSpec.scala
+++ b/test/uk/gov/hmrc/pushnotification/services/CallbackServiceSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pushnotification.services
 import org.joda.time.Duration
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import reactivemongo.bson.BSONObjectID
@@ -65,22 +65,22 @@ class CallbackServiceSpec extends UnitSpec with ScalaFutures with WithFakeApplic
   }
 
   private trait LockOK extends Setup {
-    doReturn(successful(true), Nil: _*).when(lockRepository).lock(any[String](), any[String](), any[Duration]())
-    doReturn(successful({}), Nil: _*).when(lockRepository).releaseLock(any[String](), any[String]())
+    when(lockRepository.lock(any[String](), any[String](), any[Duration]())).thenReturn(successful(true))
+    when(lockRepository.releaseLock(any[String](), any[String]())).thenReturn(successful({}))
   }
 
   private trait Success extends LockOK {
-    doReturn(successful(Seq(someCallback, otherCallback)), Nil: _*).when(mockRepository).findUndelivered(ArgumentMatchers.any[Int]())
+    when(mockRepository.findUndelivered(ArgumentMatchers.any[Int]())).thenReturn(successful(Seq(someCallback, otherCallback)))
 
-    doReturn(successful(Right(someCallback)), Nil: _*).when(mockRepository).update(someCallbackResult)
-    doReturn(successful(Left("Something is wrong")), Nil: _*).when(mockRepository).update(otherCallbackResult)
+    when(mockRepository.update(someCallbackResult)).thenReturn(successful(Right(someCallback)))
+    when(mockRepository.update(otherCallbackResult)).thenReturn(successful(Left("Something is wrong")))
   }
 
   private trait Failed extends LockOK {
 
-    doReturn(failed(new Exception("SPLAT!")), Nil: _*).when(mockRepository).findUndelivered(ArgumentMatchers.any[Int]())
+    when(mockRepository.findUndelivered(ArgumentMatchers.any[Int]())).thenReturn(failed(new Exception("SPLAT!")))
 
-    doReturn(failed(new Exception("SPLAT!")), Nil: _*).when(mockRepository).update(any[CallbackResult]())
+    when(mockRepository.update(any[CallbackResult]())).thenReturn(failed(new Exception("SPLAT!")))
   }
 
   "CallbackService getUndeliveredCallbacks" should {

--- a/test/uk/gov/hmrc/pushnotification/services/NotificationsServiceSpec.scala
+++ b/test/uk/gov/hmrc/pushnotification/services/NotificationsServiceSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pushnotification.services
 import org.joda.time.Duration
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import reactivemongo.bson.BSONObjectID
@@ -56,23 +56,23 @@ class NotificationsServiceSpec extends UnitSpec with ScalaFutures with WithFakeA
   }
 
   private trait LockOK extends Setup {
-    doReturn(successful(true), Nil: _* ).when(lockRepository).lock(any[String](), any[String](), any[Duration]())
-    doReturn(successful({}), Nil: _* ).when(lockRepository).releaseLock(any[String](), any[String]())
+    when(lockRepository.lock(any[String](), any[String](), any[Duration]())).thenReturn(successful(true))
+    when(lockRepository.releaseLock(any[String](), any[String]())).thenReturn(successful({}))
   }
 
   private trait Success extends LockOK {
-    doReturn(successful(Seq(somePersisted, otherPersisted)), Nil: _* ).when(notificationRepository).getQueuedNotifications(any[Int]())
-    doReturn(successful(Some(5)), Nil: _* ).when(notificationRepository).permanentlyFail()
-    doReturn(successful(Seq(otherPersisted, somePersisted)), Nil: _* ).when(notificationRepository).getTimedOutNotifications(any[Long](), any[Int]())
-    doReturn(successful(Right(somePersisted)), Nil: _* ).when(notificationRepository).update(ArgumentMatchers.eq(NotificationResult(someNotificationId, Delivered)))
-    doReturn(successful(Left("KABOOM!")), Nil: _* ).when(notificationRepository).update(ArgumentMatchers.eq(NotificationResult(otherNotificationId, Queued)))
+    when(notificationRepository.getQueuedNotifications(any[Int]())).thenReturn(successful(Seq(somePersisted, otherPersisted)))
+    when(notificationRepository.permanentlyFail()).thenReturn(successful(Some(5)))
+    when(notificationRepository.getTimedOutNotifications(any[Long](), any[Int]())).thenReturn(successful(Seq(otherPersisted, somePersisted)))
+    when(notificationRepository.update(ArgumentMatchers.eq(NotificationResult(someNotificationId, Delivered)))).thenReturn(successful(Right(somePersisted)))
+    when(notificationRepository.update(ArgumentMatchers.eq(NotificationResult(otherNotificationId, Queued)))).thenReturn(successful(Left("KABOOM!")))
   }
 
   private trait Failed extends LockOK {
-    doReturn(successful(None), Nil: _* ).when(notificationRepository).permanentlyFail()
-    doReturn(failed(new Exception("KAPOW!")), Nil: _* ).when(notificationRepository).getQueuedNotifications(any[Int]())
-    doReturn(failed(new Exception("SPLAT!")), Nil: _* ).when(notificationRepository).getTimedOutNotifications(any[Long](), any[Int]())
-    doReturn(failed(new Exception("CRASH!")), Nil: _* ).when(notificationRepository).update(any[NotificationResult]())
+    when(notificationRepository.permanentlyFail()).thenReturn(successful(None))
+    when(notificationRepository.getQueuedNotifications(any[Int]())).thenReturn(failed(new Exception("KAPOW!")))
+    when(notificationRepository.getTimedOutNotifications(any[Long](), any[Int]())).thenReturn(failed(new Exception("SPLAT!")))
+    when(notificationRepository.update(any[NotificationResult]())).thenReturn(failed(new Exception("CRASH!")))
   }
 
   "NotificationsService getQueuedNotifications" should {


### PR DESCRIPTION
As recommended by Mockito Javadoc: https://static.javadoc.io/org.mockito/mockito-core/2.10.0/org/mockito/Mockito.html#doReturn-java.lang.Object-

_Beware that when(Object) is always recommended for stubbing because it is argument type-safe and more readable_

Note that this commit also contains a couple of changes from answer to return in PushMessageServiceSpec where use of an answer seemed unnecessary. This changes behaviour: BSONObjectID.generate is now called only once when the mocking is set up instead of every time the mocked method is called.